### PR TITLE
feat:#14 동시성 이슈 DB수준+낙관적 락 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,33 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Spring Boot Test (JUnit 5 포함)
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // Lombok for Test
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    testRuntimeOnly 'com.h2database:h2'
+    testImplementation 'com.mysql:mysql-connector-j'
+    testImplementation 'org.testcontainers:testcontainers:1.19.3'
+    testImplementation 'org.testcontainers:mysql:1.19.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
+
 }
+test {
+    useJUnitPlatform()
+
+    // 테스트 실행 시 로그 출력
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+    }
+}
+    /*
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+     */

--- a/src/main/java/com/_37collaborationserver/domain/product/entity/Product.java
+++ b/src/main/java/com/_37collaborationserver/domain/product/entity/Product.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.persistence.Version;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -15,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@DynamicUpdate
 public class Product {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +29,7 @@ public class Product {
 	@Column(nullable = false)
 	private String imageUrl;
 
-	@Column(nullable = false)
+	@Column(nullable = false,name = "delivery_day")
 	private String day;
 
 	@Column(nullable = true)
@@ -41,14 +44,21 @@ public class Product {
 	@Column(nullable = false)
 	private String name;
 
-	public Product(int price, String imageUrl, String day, String info, String manual, String guide, String name) {
+	@Column(nullable = false)
+	private int stock;
+
+	@Version
+	private Long version;
+
+	public Product(int price, String imageUrl, String day, String info, String manual, String guide, String name,int stock) {
 		this.price = price;
 		this.imageUrl = imageUrl;
 		this.day = day;
 		this.info = info;
-		this.usageManual = usageManual;
+		this.usageManual = manual;
 		this.guide = guide;
 		this.name = name;
+		this.stock = stock;
 	}
 
 	public String getExchangeDate() {
@@ -59,5 +69,16 @@ public class Product {
 		} catch (NumberFormatException e) {
 			return this.day;
 		}
+	}
+
+	public void decreaseStock(int quantity) {
+		if (this.stock < quantity) {
+			throw new IllegalStateException("재고가 부족합니다. 현재 재고: " + this.stock);
+		}
+		this.stock -= quantity;
+	}
+
+	public boolean hasStock(int quantity) {
+		return this.stock >= quantity;
 	}
 }

--- a/src/main/java/com/_37collaborationserver/domain/product/service/ProductTransactionService.java
+++ b/src/main/java/com/_37collaborationserver/domain/product/service/ProductTransactionService.java
@@ -1,0 +1,77 @@
+package com._37collaborationserver.domain.product.service;
+
+import com._37collaborationserver.domain.product.entity.Product;
+import com._37collaborationserver.domain.product.entity.UserProduct;
+import com._37collaborationserver.domain.product.repository.ProductRepository;
+import com._37collaborationserver.domain.product.repository.UserProductRepository;
+import com._37collaborationserver.domain.user.entity.User;
+import com._37collaborationserver.domain.user.repository.UserRepository;
+import com._37collaborationserver.domain.user.service.UserService;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductTransactionService {
+
+    private final ProductRepository productRepository;
+    private final UserProductRepository userProductRepository;
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final EntityManager entityManager;
+
+    /**
+     * 실제 포인트 교환 로직 (트랜잭션 내부)
+     *
+     * 이 메서드는 별도 클래스에 있어야 @Transactional이 제대로 작동함!
+     */
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public void executeChangePoint(final Long userId, final Long productId) {
+        // 1. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다"));
+
+        // 2. 상품 조회 (version 포함)
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다"));
+
+        log.info("조회 완료 - userId: {}, productId: {}, 재고: {}, version: {}",
+                userId, productId, product.getStock(), product.getVersion());
+
+        // 3. 재고 확인
+        if (!product.hasStock(1)) {
+            log.warn("재고 부족 (productId: {}, 현재 재고: {})", productId, product.getStock());
+            throw new IllegalStateException("재고 부족");
+        }
+
+        // 4. 포인트 확인
+        if (user.getCurrentPoint() < product.getPrice()) {
+            throw new IllegalStateException("포인트 부족");
+        }
+
+        // 5. 재고 감소 (Dirty Checking으로 자동 UPDATE)
+        product.decreaseStock(1);
+
+        // 6. 포인트 차감 (Dirty Checking으로 자동 UPDATE)
+        user.updatePoint(product.getPrice());
+
+        // 7. 교환 내역 저장
+        UserProduct userProduct = new UserProduct(user, product);
+        userProductRepository.save(userProduct);
+
+        entityManager.flush();
+
+        log.info("교환 성공 (userId: {}, productId: {}, version: {})",
+                userId, productId, product.getVersion());
+    }
+
+    private Product findProductById(final Long productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다"));
+    }
+}

--- a/src/main/java/com/_37collaborationserver/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/_37collaborationserver/global/exception/code/ErrorCode.java
@@ -37,6 +37,9 @@ public enum ErrorCode {
 	INVALID_SORT_OPTION(HttpStatus.BAD_REQUEST, "E400006", "유효하지 않은 정렬 옵션입니다. (default, price_asc, price_desc 중 선택)"),
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "E404003", "상품이 존재하지 않습니다"),
 
+	PRODUCT_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "E400007","상품의 재고가 부족합니다."),
+	EXCHANGE_FAILED_DUE_TO_CONCURRENCY(HttpStatus.CONFLICT, "E409001","동시 교환 요청으로 인해 처리에 실패했습니다. 다시 시도해주세요."),
+
 	/* 500 INTERNAL SERVER ERROR */
 
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001", "서버 내부에서 오류가 발생했습니다");


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #14 

## 📝 Summary

재고가 있는 상품에 대해 여러 사용자가 동시에 교환을 시도할 때 발생할 수 있는 동시성 문제를 낙관적 락(Optimistic Lock)을 통해 해결

1. 낙관적 락 적용 (JPA @Version)
동작 원리:
- 엔티티 조회 시 version 값도 함께 조회
- UPDATE 시 WHERE id=? AND version=? 조건으로 실행
- 다른 트랜잭션이 먼저 수정했다면 version이 변경되어 UPDATE 실패
- ObjectOptimisticLockingFailureException 발생

2. 트랜잭션 분리 및 재시도 로직
트랜잭션 분리 이유:
- changePoint()는 트랜잭션 없음 → 재시도 로직만 담당
- executeChangePoint()에 @Transactional → 각 재시도마다 새로운 트랜잭션 시작
- 같은 클래스 내부 호출 시 Spring AOP 프록시가 적용되지 않아 트랜잭션이 시작되지 않음

3. 데이터베이스 레벨 보장 : @DynamicUpdate 적용
- Hibernate가 모든 컬럼을 업데이트하는 대신 변경된 컬럼만 UPDATE
- 불필요한 락 경합 감소

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
